### PR TITLE
bdgest: ensure integer for Pages, fix Volumes when fetch integrales

### DIFF
--- a/bdnex/lib/bdgest.py
+++ b/bdnex/lib/bdgest.py
@@ -394,6 +394,14 @@ class BdGestParse():
             except:
                 pass
 
+        if isinstance(album_meta_dict['Planches'], str):
+            album_meta_dict['Planches'] = int(album_meta_dict['Planches'])
+        if isinstance(album_meta_dict['Tome'], str):
+            regex = re.compile(r'(\d+|\s+)')
+            r = regex.split(album_meta_dict['Tome'])
+            tome = list(filter(None, r))[-1]
+            album_meta_dict['Tome']= int(tome)
+
         self.album_meta_dict = album_meta_dict
         comicrack_dict = self.comicinfo_metadata(album_meta_dict)
 


### PR DESCRIPTION
PageCount must be an integer, as defined in ComicInfo xsd schema.
Sometimes it appear to be a string (https://m.bedetheque.com/BD-Yuna-Tome-3-L-Ombre-de-la-Tarasque-123516.html), cast it to an integer in order to fix that.
Also, fix Volume, when we fetch "Integrales" like here: https://m.bedetheque.com/BD-Xoco-INT01-Cycle-1-79776.html

Signed-off-by: Jean-Philippe Menil <jpmenil@gmail.com>