### PR TITLE
comicrack: do not add ComicInfo.xml twice when cbr

### DIFF
--- a/bdnex/lib/comicrack.py
+++ b/bdnex/lib/comicrack.py
@@ -58,7 +58,6 @@ class comicInfo():
             # compress as cbz
             new_filename = self.input_filename.replace('.cbr', '.cbz')
             with zipfile.ZipFile(new_filename, 'w') as zipf:
-                zipf.write(comic_info_fp, 'ComicInfo.xml')
                 for folderName, subfolders, filenames in os.walk(tmpdir):
                     for filename in filenames:
                         # create complete filepath of file in directory


### PR DESCRIPTION
Since we already copy the ComicInfo.xml file in the tmpdir, there's no need add it a second time.

Signed-off-by: Jean-Philippe Menil <jpmenil@gmail.com>